### PR TITLE
Cleaned out dependencies that are only needed for the api library

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,5 @@
+# Repo consistant format configuration
+
+indent_style = "Visual" #default is Block
+control_brace_style = "AlwaysSameLine" #default
+fn_args_density = "Compressed" #default is Tall

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,19 +5,15 @@ authors = ["Connor Postma <connor.postma@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+# The Discord API crate
+ferriscord = { directory = "../ferriscord/"}
 # Debug logging
-env_logger = "0.6.1"
-# Helper to retreive
+env_logger = "0.6"
+# Helper to retreive .env
 dotenv = "0.14"
 # The most fun web and actor system framework
 actix = "0.8.1"
 actix-web = "1.0.0-beta.3"
 actix-rt = "0.2.2"
-# A handle bars based html engine. Very fast, and includes templates on compile time
-yarte = { version = "0.2", features = ["with-actix-web"] }
-# Serialization
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = "1.0"
 # An adorable little crustacean that just want's to say hello
 ferris_says = "0.1.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,6 @@ fn main() {
     // Initialize a new bot connection
     let con = discord_api::Connection::new(bot_token)
         .with_prefix('!') // the prefix to listen to for commands
-        .with_default_help() // a default auto generated !help command
         .with_commands(say, ping) // register the bot's commands
         .with_events(on_ready, on_message) // register all event callbacks
         .run(); // start the bot


### PR DESCRIPTION
This of course still does not build as there is no working library just yet, but nonetheless it is closer to what it will be when it does work.

Changes:
- Removed some dependencies
- Removed .with_default_help() in favour of there always being a default help command unless otherwise specified.